### PR TITLE
Fix staff, care plan, and gfp functionality

### DIFF
--- a/client/src/components/client-detail-view.tsx
+++ b/client/src/components/client-detail-view.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
 import {
   ImplementationPlanDialog,
   SimpleImplementationPlanDialog,
@@ -72,10 +73,12 @@ export function ClientDetailView({ client, staffId }: ClientDetailViewProps) {
   // Fetch all client-related data
   const { data: carePlan } = useQuery<CarePlan>({
     queryKey: ["/api/care-plans", client.id],
+    queryFn: () => api.getCarePlanByClient(client.id),
   });
 
   const { data: implementationPlan } = useQuery<ImplementationPlan>({
     queryKey: ["/api/implementation-plans", client.id],
+    queryFn: () => api.getImplementationPlanByClient(client.id),
   });
 
   const { data: weeklyDocs = [] } = useQuery<WeeklyDocumentation[]>({
@@ -89,6 +92,80 @@ export function ClientDetailView({ client, staffId }: ClientDetailViewProps) {
   const { data: vimsaTimeData = [] } = useQuery<VimsaTime[]>({
     queryKey: ["/api/vimsa-time", client.id],
   });
+
+  // Editable drafts + autosave for Care Plan and GFP
+  const [carePlanDraft, setCarePlanDraft] = useState<any | null>(null);
+  const [gfpDraft, setGfpDraft] = useState<any | null>(null);
+  const [cpHasChanges, setCpHasChanges] = useState(false);
+  const [gfpHasChanges, setGfpHasChanges] = useState(false);
+  const cpTimer = useRef<any>(null);
+  const gfpTimer = useRef<any>(null);
+  const [cpSavedAt, setCpSavedAt] = useState<string>("");
+  const [gfpSavedAt, setGfpSavedAt] = useState<string>("");
+
+  useEffect(() => {
+    if (carePlan) {
+      setCarePlanDraft({ ...carePlan });
+      setCpHasChanges(false);
+    }
+  }, [carePlan]);
+
+  useEffect(() => {
+    if (implementationPlan) {
+      setGfpDraft({ ...implementationPlan });
+      setGfpHasChanges(false);
+    }
+  }, [implementationPlan]);
+
+  function triggerCpAutosave() {
+    if (!carePlan || !carePlanDraft) return;
+    if (cpTimer.current) clearTimeout(cpTimer.current);
+    cpTimer.current = setTimeout(async () => {
+      try {
+        await api.updateCarePlan(carePlan.id, {
+          receivedDate: carePlanDraft.receivedDate ?? null,
+          enteredJournalDate: carePlanDraft.enteredJournalDate ?? null,
+          staffNotifiedDate: carePlanDraft.staffNotifiedDate ?? null,
+          status: carePlanDraft.status ?? "received",
+          planContent: carePlanDraft.planContent ?? "",
+          goals: carePlanDraft.goals ?? "",
+          interventions: carePlanDraft.interventions ?? "",
+          comment: carePlanDraft.comment ?? "",
+        });
+        setCpHasChanges(false);
+        setCpSavedAt("Sparad nyss");
+        queryClient.invalidateQueries({ queryKey: ["/api/care-plans", client.id] });
+        toast({ title: "Vårdplan sparad" });
+      } catch {
+        toast({ title: "Fel vid autospara", variant: "destructive" });
+      }
+    }, 800);
+  }
+
+  function triggerGfpAutosave() {
+    if (!implementationPlan || !gfpDraft) return;
+    if (gfpTimer.current) clearTimeout(gfpTimer.current);
+    gfpTimer.current = setTimeout(async () => {
+      try {
+        await api.updateImplementationPlan(implementationPlan.id, {
+          planContent: gfpDraft.planContent ?? "",
+          goals: gfpDraft.goals ?? "",
+          activities: gfpDraft.activities ?? "",
+          followUpSchedule: gfpDraft.followUpSchedule ?? "",
+          status: gfpDraft.status ?? "pending",
+          completedDate: gfpDraft.completedDate || null,
+          sentDate: gfpDraft.sentDate || null,
+          comments: gfpDraft.comments ?? "",
+        });
+        setGfpHasChanges(false);
+        setGfpSavedAt("Sparad nyss");
+        queryClient.invalidateQueries({ queryKey: ["/api/implementation-plans", client.id] });
+        toast({ title: "GFP sparad" });
+      } catch {
+        toast({ title: "Fel vid autospara", variant: "destructive" });
+      }
+    }, 800);
+  }
 
   // Mutation to update client's responsible staff
   const updateClientStaffMutation = useMutation({
@@ -408,13 +485,21 @@ export function ClientDetailView({ client, staffId }: ClientDetailViewProps) {
                     <Input
                       type="date"
                       value={
-                        carePlan?.receivedDate
-                          ? new Date(carePlan.receivedDate)
+                        carePlanDraft?.receivedDate
+                          ? new Date(carePlanDraft.receivedDate)
                               .toISOString()
                               .split("T")[0]
                           : ""
                       }
                       className="mt-1"
+                      onChange={(e) => {
+                        setCarePlanDraft((d: any) => ({
+                          ...d,
+                          receivedDate: e.target.value || null,
+                        }));
+                        setCpHasChanges(true);
+                        triggerCpAutosave();
+                      }}
                     />
                   </div>
                   <div>
@@ -424,13 +509,21 @@ export function ClientDetailView({ client, staffId }: ClientDetailViewProps) {
                     <Input
                       type="date"
                       value={
-                        carePlan?.enteredJournalDate
-                          ? new Date(carePlan.enteredJournalDate)
+                        carePlanDraft?.enteredJournalDate
+                          ? new Date(carePlanDraft.enteredJournalDate)
                               .toISOString()
                               .split("T")[0]
                           : ""
                       }
                       className="mt-1"
+                      onChange={(e) => {
+                        setCarePlanDraft((d: any) => ({
+                          ...d,
+                          enteredJournalDate: e.target.value || null,
+                        }));
+                        setCpHasChanges(true);
+                        triggerCpAutosave();
+                      }}
                     />
                   </div>
                   <div>
@@ -440,13 +533,21 @@ export function ClientDetailView({ client, staffId }: ClientDetailViewProps) {
                     <Input
                       type="date"
                       value={
-                        carePlan?.staffNotifiedDate
-                          ? new Date(carePlan.staffNotifiedDate)
+                        carePlanDraft?.staffNotifiedDate
+                          ? new Date(carePlanDraft.staffNotifiedDate)
                               .toISOString()
                               .split("T")[0]
                           : ""
                       }
                       className="mt-1"
+                      onChange={(e) => {
+                        setCarePlanDraft((d: any) => ({
+                          ...d,
+                          staffNotifiedDate: e.target.value || null,
+                        }));
+                        setCpHasChanges(true);
+                        triggerCpAutosave();
+                      }}
                     />
                   </div>
                 </div>
@@ -468,17 +569,81 @@ export function ClientDetailView({ client, staffId }: ClientDetailViewProps) {
                   <label className="text-sm font-medium">Status</label>
                   <Badge
                     className={`mt-1 ${getStatusColor(
-                      carePlan?.status || "received"
+                      (carePlanDraft?.status as any) || "received"
                     )}`}
                   >
-                    {carePlan?.status === "received" && "Mottagen"}
-                    {carePlan?.status === "entered_journal" &&
+                    {carePlanDraft?.status === "received" && "Mottagen"}
+                    {carePlanDraft?.status === "entered_journal" &&
                       "Inlagd i journal"}
-                    {carePlan?.status === "staff_notified" &&
+                    {carePlanDraft?.status === "staff_notified" &&
                       "Personal tillsagd"}
-                    {carePlan?.status === "gfp_pending" && "Väntar på GFP"}
-                    {carePlan?.status === "completed" && "Slutförd"}
+                    {carePlanDraft?.status === "gfp_pending" && "Väntar på GFP"}
+                    {carePlanDraft?.status === "completed" && "Slutförd"}
                   </Badge>
+                  <div className="mt-2 flex items-center gap-3 flex-wrap">
+                    {cpHasChanges && (
+                      <span className="text-xs text-muted-foreground">Sparar...</span>
+                    )}
+                    {cpSavedAt && !cpHasChanges && (
+                      <span className="text-xs text-muted-foreground">{cpSavedAt}</span>
+                    )}
+                    {carePlan && (
+                      <Button
+                        size="sm"
+                        className="text-xs"
+                        onClick={async () => {
+                          try {
+                            await api.updateCarePlan(carePlan.id, {
+                              receivedDate: carePlanDraft?.receivedDate ?? null,
+                              enteredJournalDate:
+                                carePlanDraft?.enteredJournalDate ?? null,
+                              staffNotifiedDate:
+                                carePlanDraft?.staffNotifiedDate ?? null,
+                              status: carePlanDraft?.status ?? "received",
+                              planContent: carePlanDraft?.planContent ?? "",
+                              goals: carePlanDraft?.goals ?? "",
+                              interventions: carePlanDraft?.interventions ?? "",
+                              comment: carePlanDraft?.comment ?? "",
+                            });
+                            setCpHasChanges(false);
+                            setCpSavedAt("Sparad nyss");
+                            queryClient.invalidateQueries({
+                              queryKey: ["/api/care-plans", client.id],
+                            });
+                            toast({ title: "Vårdplan sparad" });
+                          } catch {
+                            toast({
+                              title: "Fel vid sparande",
+                              variant: "destructive",
+                            });
+                          }
+                        }}
+                      >
+                        Spara
+                      </Button>
+                    )}
+                    {carePlan && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="text-xs text-red-600"
+                        onClick={async () => {
+                          if (!window.confirm("Ta bort vårdplanen?")) return;
+                          try {
+                            await api.deleteCarePlan(carePlan.id);
+                            queryClient.invalidateQueries({
+                              queryKey: ["/api/care-plans", client.id],
+                            });
+                            toast({ title: "Vårdplan raderad" });
+                          } catch {
+                            toast({ title: "Fel vid radering", variant: "destructive" });
+                          }
+                        }}
+                      >
+                        Ta bort
+                      </Button>
+                    )}
+                  </div>
                 </div>
               </div>
             </CardContent>
@@ -514,14 +679,18 @@ export function ClientDetailView({ client, staffId }: ClientDetailViewProps) {
                       <Input
                         type="date"
                         value={
-                          implementationPlan?.dueDate
-                            ? new Date(implementationPlan.dueDate)
+                          gfpDraft?.dueDate
+                            ? new Date(gfpDraft.dueDate)
                                 .toISOString()
                                 .split("T")[0]
                             : ""
                         }
                         className="mt-1"
-                        disabled
+                        onChange={(e) => {
+                          setGfpDraft((d: any) => ({ ...d, dueDate: e.target.value || null }));
+                          setGfpHasChanges(true);
+                          triggerGfpAutosave();
+                        }}
                       />
                     </div>
                     <div>
@@ -531,14 +700,18 @@ export function ClientDetailView({ client, staffId }: ClientDetailViewProps) {
                       <Input
                         type="date"
                         value={
-                          implementationPlan?.completedDate
-                            ? new Date(implementationPlan.completedDate)
+                          gfpDraft?.completedDate
+                            ? new Date(gfpDraft.completedDate)
                                 .toISOString()
                                 .split("T")[0]
                             : ""
                         }
                         className="mt-1"
-                        disabled
+                        onChange={(e) => {
+                          setGfpDraft((d: any) => ({ ...d, completedDate: e.target.value || null }));
+                          setGfpHasChanges(true);
+                          triggerGfpAutosave();
+                        }}
                       />
                     </div>
                   </div>
@@ -547,55 +720,69 @@ export function ClientDetailView({ client, staffId }: ClientDetailViewProps) {
                     <label className="text-sm font-medium">Status</label>
                     <Badge
                       className={`mt-1 ${getStatusColor(
-                        implementationPlan?.status || "pending",
+                        (gfpDraft?.status as any) || "pending",
                         isGfpOverdue()
                       )}`}
                     >
                       {isGfpOverdue() &&
-                        implementationPlan?.status !== "completed" &&
+                        gfpDraft?.status !== "completed" &&
                         "FÖRSENAD - "}
-                      {implementationPlan?.status === "pending" && "Väntande"}
-                      {implementationPlan?.status === "in_progress" &&
+                      {gfpDraft?.status === "pending" && "Väntande"}
+                      {gfpDraft?.status === "in_progress" &&
                         "Pågående"}
-                      {implementationPlan?.status === "completed" && "Slutförd"}
-                      {implementationPlan?.status === "sent" && "Skickad"}
+                      {gfpDraft?.status === "completed" && "Slutförd"}
+                      {gfpDraft?.status === "sent" && "Skickad"}
                     </Badge>
                   </div>
 
-                  {implementationPlan?.planContent && (
+                  {gfpDraft && (
                     <div>
                       <label className="text-sm font-medium">
                         Planinnehåll
                       </label>
-                      <div className="mt-1 p-3 bg-gray-50 rounded border">
-                        <p className="text-sm">
-                          {implementationPlan.planContent}
-                        </p>
-                      </div>
+                      <Textarea
+                        className="mt-1"
+                        value={gfpDraft.planContent || ""}
+                        onChange={(e) => {
+                          setGfpDraft((d: any) => ({ ...d, planContent: e.target.value }));
+                          setGfpHasChanges(true);
+                          triggerGfpAutosave();
+                        }}
+                      />
                     </div>
                   )}
 
-                  {implementationPlan?.goals && (
+                  {gfpDraft && (
                     <div>
                       <label className="text-sm font-medium">Mål</label>
-                      <div className="mt-1 p-3 bg-gray-50 rounded border">
-                        <p className="text-sm">{implementationPlan.goals}</p>
-                      </div>
+                      <Textarea
+                        className="mt-1"
+                        value={gfpDraft.goals || ""}
+                        onChange={(e) => {
+                          setGfpDraft((d: any) => ({ ...d, goals: e.target.value }));
+                          setGfpHasChanges(true);
+                          triggerGfpAutosave();
+                        }}
+                      />
                     </div>
                   )}
 
-                  {implementationPlan?.activities && (
+                  {gfpDraft && (
                     <div>
                       <label className="text-sm font-medium">Aktiviteter</label>
-                      <div className="mt-1 p-3 bg-gray-50 rounded border">
-                        <p className="text-sm">
-                          {implementationPlan.activities}
-                        </p>
-                      </div>
+                      <Textarea
+                        className="mt-1"
+                        value={gfpDraft.activities || ""}
+                        onChange={(e) => {
+                          setGfpDraft((d: any) => ({ ...d, activities: e.target.value }));
+                          setGfpHasChanges(true);
+                          triggerGfpAutosave();
+                        }}
+                      />
                     </div>
                   )}
 
-                  {implementationPlan?.completedDate && (
+                  {gfpDraft?.completedDate && (
                     <div className="p-3 bg-green-50 rounded-lg border border-green-200">
                       <p className="text-sm text-green-800 flex items-center gap-2">
                         <CheckCircle className="h-4 w-4" />
@@ -603,6 +790,81 @@ export function ClientDetailView({ client, staffId }: ClientDetailViewProps) {
                       </p>
                     </div>
                   )}
+
+                  <div className="flex items-center gap-3 flex-wrap">
+                    {gfpHasChanges && (
+                      <span className="text-xs text-muted-foreground">Sparar...</span>
+                    )}
+                    {gfpSavedAt && !gfpHasChanges && (
+                      <span className="text-xs text-muted-foreground">{gfpSavedAt}</span>
+                    )}
+                    {implementationPlan && (
+                      <>
+                        <Button
+                          size="sm"
+                          className="text-xs"
+                          onClick={async () => {
+                            try {
+                              await api.updateImplementationPlan(
+                                implementationPlan.id,
+                                {
+                                  planContent: gfpDraft?.planContent ?? "",
+                                  goals: gfpDraft?.goals ?? "",
+                                  activities: gfpDraft?.activities ?? "",
+                                  followUpSchedule:
+                                    gfpDraft?.followUpSchedule ?? "",
+                                  status: gfpDraft?.status ?? "pending",
+                                  completedDate: gfpDraft?.completedDate || null,
+                                  sentDate: gfpDraft?.sentDate || null,
+                                  comments: gfpDraft?.comments ?? "",
+                                }
+                              );
+                              setGfpHasChanges(false);
+                              setGfpSavedAt("Sparad nyss");
+                              queryClient.invalidateQueries({
+                                queryKey: ["/api/implementation-plans", client.id],
+                              });
+                              toast({ title: "GFP sparad" });
+                            } catch {
+                              toast({
+                                title: "Fel vid sparande",
+                                variant: "destructive",
+                              });
+                            }
+                          }}
+                        >
+                          Spara
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="text-xs text-red-600"
+                          onClick={async () => {
+                            if (!window.confirm("Ta bort GFP?")) return;
+                            try {
+                              await api.deleteImplementationPlan(
+                                implementationPlan.id
+                              );
+                              queryClient.invalidateQueries({
+                                queryKey: [
+                                  "/api/implementation-plans",
+                                  client.id,
+                                ],
+                              });
+                              toast({ title: "GFP raderad" });
+                            } catch {
+                              toast({
+                                title: "Fel vid radering",
+                                variant: "destructive",
+                              });
+                            }
+                          }}
+                        >
+                          Radera
+                        </Button>
+                      </>
+                    )}
+                  </div>
                 </div>
               ) : (
                 <div className="text-center py-8">

--- a/client/src/components/staff-sidebar.tsx
+++ b/client/src/components/staff-sidebar.tsx
@@ -73,7 +73,20 @@ export function StaffSidebar({
 
   // Delete staff mutation
   const deleteStaffMutation = useMutation({
-    mutationFn: (id: string) => api.deleteStaff(id),
+    mutationFn: async (id: string) => {
+      // Check usage first
+      const usage = await api.getStaffUsage(id).catch(() => ({ clientCount: 0 } as any));
+      if (usage.clientCount > 0) {
+        const confirm = window.confirm(
+          `Denna personal är kopplad till ${usage.clientCount} klient(er).\n\nVälj OK för att radera och sätta Ansvarig = Oassignerad, eller Avbryt.`
+        );
+        if (!confirm) {
+          throw new Error("Radering avbröts av användaren");
+        }
+        return apiRequest("DELETE", `/api/staff/${id}?unassign=1`).then((r) => r.json());
+      }
+      return api.deleteStaff(id);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/staff"] });
       setDeletingId(null);
@@ -103,8 +116,6 @@ export function StaffSidebar({
 
   // Delete staff handler
   const handleDeleteStaff = async (id: string) => {
-    if (!window.confirm("Är du säker på att du vill ta bort denna personal?"))
-      return;
     deleteStaffMutation.mutate(id);
   };
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -135,8 +135,8 @@ export const checkAuth = (): Promise<User> =>
 
 // Care Plans API
 export const getCarePlans = (): Promise<any[]> =>
-  fetch(`${API_BASE_URL}/care-plans`, { credentials: "include" }).then((res) =>
-    handleResponse<any[]>(res)
+  fetch(`${API_BASE_URL}/care-plans/all`, { credentials: "include" }).then(
+    (res) => handleResponse<any[]>(res)
   );
 
 export const getCarePlansByStaff = (staffId: string): Promise<any[]> =>
@@ -145,7 +145,7 @@ export const getCarePlansByStaff = (staffId: string): Promise<any[]> =>
   }).then((res) => handleResponse<any[]>(res));
 
 export const getCarePlanByClient = (clientId: string): Promise<any> =>
-  fetch(`${API_BASE_URL}/care-plans/${clientId}`, {
+  fetch(`${API_BASE_URL}/clients/${clientId}/care-plan`, {
     credentials: "include",
   }).then((res) => handleResponse<any>(res));
 
@@ -156,6 +156,20 @@ export const createCarePlan = (data: any): Promise<any> =>
     credentials: "include",
     body: JSON.stringify(data),
   }).then((res) => handleResponse<any>(res));
+
+export const updateCarePlan = (id: string, data: any): Promise<any> =>
+  fetch(`${API_BASE_URL}/care-plans/${id}`, {
+    method: "PUT",
+    headers: getAuthHeaders(),
+    credentials: "include",
+    body: JSON.stringify(data),
+  }).then((res) => handleResponse<any>(res));
+
+export const deleteCarePlan = (id: string): Promise<void> =>
+  fetch(`${API_BASE_URL}/care-plans/${id}`, {
+    method: "DELETE",
+    credentials: "include",
+  }).then((res) => handleResponse<void>(res));
 
 // Implementation Plans API
 export const getImplementationPlans = (): Promise<any[]> =>
@@ -170,8 +184,10 @@ export const getImplementationPlansByStaff = (
     credentials: "include",
   }).then((res) => handleResponse<any[]>(res));
 
-export const getImplementationPlanByClient = (clientId: string): Promise<any> =>
-  fetch(`${API_BASE_URL}/implementation-plans/${clientId}`, {
+export const getImplementationPlanByClient = (
+  clientId: string
+): Promise<any> =>
+  fetch(`${API_BASE_URL}/clients/${clientId}/implementation-plan`, {
     credentials: "include",
   }).then((res) => handleResponse<any>(res));
 
@@ -195,6 +211,17 @@ export const updateImplementationPlan = (id: string, data: any): Promise<any> =>
     credentials: "include",
     body: JSON.stringify(data),
   }).then((res) => handleResponse<any>(res));
+
+export const deleteImplementationPlan = (id: string): Promise<void> =>
+  fetch(`${API_BASE_URL}/implementation-plans/${id}`, {
+    method: "DELETE",
+    credentials: "include",
+  }).then((res) => handleResponse<void>(res));
+
+export const getStaffUsage = (id: string): Promise<{clientCount: number; clientIds: string[]}> =>
+  fetch(`${API_BASE_URL}/staff/${id}/usage`, {
+    credentials: "include",
+  }).then((res) => handleResponse<{clientCount: number; clientIds: string[]}>(res));
 
 // Weekly Documentation API
 export const getWeeklyDocumentation = (): Promise<any[]> =>

--- a/client/src/lib/staff-data.ts
+++ b/client/src/lib/staff-data.ts
@@ -1,16 +1,46 @@
 export const staffList = [
-  "Afif Derbas", "Ahmed Alrakabi", "Ahmed Ramadan", "Ajmen Rafiq", "Alana Salah",
-  "Alharis Albayati", "Amir Al-istarabadi", "Anjelika Bååth", "Bashdar Reza",
-  "Constanza Soto", "Deni Dulji", "Diana Gharib", "Drilon Muqkurtaj", "Heidar Farhan",
-  "Hussein Ahmed", "Ida Björkbacka", "Ikhlas Almaliki", "Intisar Almansour",
-  "Israa Touman", "Johan Wessberg", "Kaoula Channoufi", "Kim Torneus", "Lejla Kocacik",
-  "Michelle Nilsson", "Mirza Celik", "Mirza Hodzic", "Nasima Kuraishe",
-  "Nicolas Lazcano", "Omar Mezza", "Qasin Abdullahi", "Robert Ackar", "Samir Bezzina",
-  "Sebastian Holm", "Wissam Hemissi", "Yasmin Ibrahim"
+  "Afif Derbas-",
+  "Ahmed Alrakabi",
+  "Ahmed Ramadan –",
+  "Ajmen Rafiq-",
+  "Alana Salah-",
+  "Alharis Albayati",
+  "Amir Al-Istarabadi  -",
+  "Anjelika Bååth-",
+  "Bashdar Reza –",
+  "Constanza Soto",
+  "Deni Dulji",
+  "Diana Gharib",
+  "Drilon Muqkurtaj",
+  "Heidar Farhan",
+  "Hussein Ahmed",
+  "Ida Björkbacka",
+  "Ikhlas Almaliki",
+  "Intisar Almansour",
+  "Israa Touman",
+  "Johan Wessberg",
+  "Kim Torneus",
+  "Lejla Kocacik",
+  "Mirza Celik",
+  "Mirza Hodzic",
+  "Nasima Kuraishe",
+  "Nicolas Lazcano",
+  "Omar Mezza",
+  "Qasin Abdullahi",
+  "Robert Ackar",
+  "Samir Bezzina",
+  "Sebastian Holm",
+  "Wissam Hemissi",
+  "Yasmin Ibrahim",
 ];
 
 export function getInitials(name: string): string {
-  return name.split(' ').map(n => n[0]).join('');
+  const full = name.replace(/[\-–]\s*$/u, "").trim();
+  return full
+    .split(" ")
+    .filter(Boolean)
+    .map((n) => n[0])
+    .join("");
 }
 
 export function getStatusColor(status: string): string {

--- a/server/routes/dev.ts
+++ b/server/routes/dev.ts
@@ -43,7 +43,80 @@ devRoutes.get("/auth/session", (req, res) => {
 });
 
 // === STAFF ===
+// Seed helper to ensure exact staff list exists with displayName/fullName
+const STAFF_DISPLAY_NAMES = [
+  "Afif Derbas-",
+  "Ahmed Alrakabi",
+  "Ahmed Ramadan –",
+  "Ajmen Rafiq-",
+  "Alana Salah-",
+  "Alharis Albayati",
+  "Amir Al-Istarabadi  -",
+  "Anjelika Bååth-",
+  "Bashdar Reza –",
+  "Constanza Soto",
+  "Deni Dulji",
+  "Diana Gharib",
+  "Drilon Muqkurtaj",
+  "Heidar Farhan",
+  "Hussein Ahmed",
+  "Ida Björkbacka",
+  "Ikhlas Almaliki",
+  "Intisar Almansour",
+  "Israa Touman",
+  "Johan Wessberg",
+  "Kim Torneus",
+  "Lejla Kocacik",
+  "Mirza Celik",
+  "Mirza Hodzic",
+  "Nasima Kuraishe",
+  "Nicolas Lazcano",
+  "Omar Mezza",
+  "Qasin Abdullahi",
+  "Robert Ackar",
+  "Samir Bezzina",
+  "Sebastian Holm",
+  "Wissam Hemissi",
+  "Yasmin Ibrahim",
+];
+
+function toFullName(displayName: string): string {
+  // Trim trailing hyphen or en-dash and extra spaces
+  return displayName.replace(/[\-–]\s*$/u, "").trim();
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((n) => n[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function ensureSeedStaff() {
+  if (!store.staff) store.staff = [];
+  const existingNames = new Set((store.staff ?? []).map((s: any) => s.name));
+  let added = 0;
+  for (const displayName of STAFF_DISPLAY_NAMES) {
+    if (!existingNames.has(displayName)) {
+      const fullName = toFullName(displayName);
+      store.staff.push({
+        id: "staff_" + randomUUID(),
+        name: displayName, // display as provided (including trailing dash if any)
+        displayName,
+        fullName,
+        initials: initialsOf(fullName),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      added++;
+    }
+  }
+  if (added > 0) persist();
+}
+
 devRoutes.get("/staff", (_req, res) => {
+  ensureSeedStaff();
   return res.json(store.staff ?? []);
 });
 
@@ -58,6 +131,42 @@ devRoutes.post("/staff", (req, res) => {
   store.staff.push(item);
   persist();
   return res.status(201).json(item);
+});
+
+// Staff usage info (linked clients count)
+devRoutes.get("/staff/:id/usage", (req, res) => {
+  const { id } = req.params;
+  const clients = (store.clients ?? []).filter((c: any) => c.staffId === id);
+  return res.json({ clientCount: clients.length, clientIds: clients.map((c: any) => c.id) });
+});
+
+// Delete staff with optional unassign
+devRoutes.delete("/staff/:id", (req, res) => {
+  const { id } = req.params;
+  const idx = (store.staff ?? []).findIndex((s: any) => s.id === id);
+  if (idx === -1) return res.status(404).json({ error: "Personal hittades inte" });
+
+  const linkedClients = (store.clients ?? []).filter((c: any) => c.staffId === id);
+  const unassign = String(req.query.unassign ?? "").toLowerCase();
+  const shouldUnassign = unassign === "1" || unassign === "true" || unassign === "yes";
+
+  if (linkedClients.length > 0 && !shouldUnassign) {
+    return res.status(409).json({
+      error: "Personal är kopplad till klienter",
+      clientCount: linkedClients.length,
+    });
+  }
+
+  if (linkedClients.length > 0 && shouldUnassign) {
+    for (const c of linkedClients) {
+      c.staffId = "Oassignerad"; // explicit label for UI
+      c.updatedAt = new Date().toISOString();
+    }
+  }
+
+  store.staff.splice(idx, 1);
+  persist();
+  return res.json({ message: "Personal borttagen" });
 });
 
 // === CLIENTS ===
@@ -172,6 +281,24 @@ devRoutes.put("/care-plans/:id", (req, res) => {
   return res.json(store.carePlans[idx]);
 });
 
+// Get latest care plan for a client
+devRoutes.get("/clients/:clientId/care-plan", (req, res) => {
+  const list = (store.carePlans ?? []).filter((p: any) => p.clientId === req.params.clientId);
+  if (!list.length) return res.status(404).json({ error: "Not found" });
+  // return most recently updated
+  const latest = list.slice().sort((a: any, b: any) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
+  return res.json(latest);
+});
+
+// Delete care plan
+devRoutes.delete("/care-plans/:id", (req, res) => {
+  const idx = (store.carePlans ?? []).findIndex((p: any) => p.id === req.params.id);
+  if (idx === -1) return res.status(404).json({ error: "Not found" });
+  store.carePlans.splice(idx, 1);
+  persist();
+  return res.status(204).send();
+});
+
 // === IMPLEMENTATION PLANS (administrativ) ===
 devRoutes.get("/implementation-plans/all", (_req, res) => {
   return res.json(store.implementationPlans ?? []);
@@ -225,6 +352,32 @@ devRoutes.put("/implementation-plans/:id", (req, res) => {
   };
   persist();
   return res.json(store.implementationPlans[idx]);
+});
+
+// Get latest implementation plan for a client (used by forms)
+devRoutes.get("/clients/:clientId/implementation-plan", (req, res) => {
+  const list = (store.implementationPlans ?? []).filter(
+    (p: any) => p.clientId === req.params.clientId
+  );
+  if (!list.length) return res.status(404).json({ error: "Not found" });
+  const latest = list
+    .slice()
+    .sort(
+      (a: any, b: any) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    )[0];
+  return res.json(latest);
+});
+
+// Delete implementation plan
+devRoutes.delete("/implementation-plans/:id", (req, res) => {
+  const idx = (store.implementationPlans ?? []).findIndex(
+    (p: any) => p.id === req.params.id
+  );
+  if (idx === -1) return res.status(404).json({ error: "Not found" });
+  store.implementationPlans.splice(idx, 1);
+  persist();
+  return res.status(204).send();
 });
 
 // === WEEKLY DOCS (inkl. lör/sön) ===


### PR DESCRIPTION
Enable staff deletion with client reassignment, add exact staff names, and implement full editing, saving, and deletion for Care Plans and GFP.

This PR resolves critical bugs where staff could not be deleted (especially when linked to clients, now offering reassignment) and Care Plan/GFP content was uneditable. It also seeds the exact staff list as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-068d9bbf-0d19-4018-a97e-674d3f72a799">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-068d9bbf-0d19-4018-a97e-674d3f72a799">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

