### PR TITLE
Investigate missing form labels in enhanced-search

### DIFF
--- a/client/src/components/quick-search.tsx
+++ b/client/src/components/quick-search.tsx
@@ -291,6 +291,7 @@ export function QuickSearch({
           }}
           onFocus={() => setIsOpen(true)}
           className="pl-10 pr-4"
+          aria-label="Sök personal, klienter eller ärenden"
         />
       </div>
 


### PR DESCRIPTION
Add `aria-label` to the quick search input to resolve a form accessibility error.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a370da7-88d9-41a7-bc7c-937ccd1e6166">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a370da7-88d9-41a7-bc7c-937ccd1e6166">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

