### PR TITLE
Investigate missing form labels in enhanced-search

### DIFF
--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -60,6 +60,9 @@ export function Header({ onSidebarToggle, onExport, searchTerm, onSearchChange }
             <div className="hidden md:block relative">
               <Input
                 type="text"
+                id="header-search"
+                role="searchbox"
+                aria-label="Sök personal eller data"
                 placeholder="Sök personal eller data..."
                 defaultValue={searchTerm}
                 onChange={handleSearchChange}

--- a/client/src/components/quick-search.tsx
+++ b/client/src/components/quick-search.tsx
@@ -282,6 +282,8 @@ export function QuickSearch({
         <Input
           ref={inputRef}
           type="text"
+          id="global-quick-search"
+          aria-label="Snabbsök: personal, klienter eller ärenden"
           placeholder={placeholder}
           value={query}
           onChange={(e) => {
@@ -291,6 +293,7 @@ export function QuickSearch({
           }}
           onFocus={() => setIsOpen(true)}
           className="pl-10 pr-4"
+          role="searchbox"
         />
       </div>
 


### PR DESCRIPTION
Add `id`, `aria-label`, and `role="searchbox"` to search inputs in `header.tsx` and `quick-search.tsx` to resolve accessibility warnings about unlabeled form elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-aabd6de7-cb3e-4345-aef3-bf8fd59b18cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aabd6de7-cb3e-4345-aef3-bf8fd59b18cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

