### PR TITLE
Investigate missing form labels in enhanced-search

### DIFF
--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -58,8 +58,11 @@ export function Header({ onSidebarToggle, onExport, searchTerm, onSearchChange }
           <div className="flex items-center space-x-4">
             {/* Search */}
             <div className="hidden md:block relative">
+              <label htmlFor="header-search-input" className="sr-only">Sök</label>
               <Input
+                id="header-search-input"
                 type="text"
+                aria-label="Sök"
                 placeholder="Sök personal eller data..."
                 defaultValue={searchTerm}
                 onChange={handleSearchChange}

--- a/client/src/components/quick-search.tsx
+++ b/client/src/components/quick-search.tsx
@@ -278,10 +278,13 @@ export function QuickSearch({
   return (
     <div ref={searchRef} className={`relative ${className}`}>
       <div className="relative">
+        <label htmlFor="quick-search-input" className="sr-only">Sök</label>
         <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
         <Input
           ref={inputRef}
+          id="quick-search-input"
           type="text"
+          aria-label="Sök"
           placeholder={placeholder}
           value={query}
           onChange={(e) => {


### PR DESCRIPTION
Add hidden labels and `aria-label` to search inputs in `quick-search.tsx` and `header.tsx` to resolve accessibility warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-daf3418c-66d4-4a7c-b114-2aab0238cac9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-daf3418c-66d4-4a7c-b114-2aab0238cac9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

